### PR TITLE
fix: improve background and text contrast

### DIFF
--- a/newtab.css
+++ b/newtab.css
@@ -109,7 +109,7 @@ body::before {
     z-index: -3;
 }
 
-/* Gentle mesh gradient overlay */
+/* Gentle mesh gradient overlay or darkening layer */
 body::after {
     content: '';
     position: fixed;
@@ -117,13 +117,20 @@ body::after {
     left: 0;
     width: 100%;
     height: 100%;
-    background: 
+    pointer-events: none;
+    z-index: -2;
+    background:
         radial-gradient(circle at 25% 25%, rgba(74, 144, 226, 0.15) 0%, transparent 60%),
         radial-gradient(circle at 75% 75%, rgba(123, 104, 238, 0.12) 0%, transparent 60%),
         radial-gradient(circle at 50% 50%, rgba(93, 173, 226, 0.1) 0%, transparent 60%);
     animation: meshMove 25s ease-in-out infinite;
-    pointer-events: none;
-    z-index: -2;
+    transition: background var(--transition-base), z-index var(--transition-base);
+}
+
+body.has-overlay::after {
+    background: rgba(0, 0, 0, 0.35);
+    animation: none;
+    z-index: 0;
 }
 
 /* Floating geometric shapes */
@@ -202,24 +209,6 @@ body::after {
     }
 }
 
-/* Overlay to ensure readability on images or gradients */
-.background-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.35);
-    pointer-events: none;
-    z-index: 0;
-    opacity: 0;
-    transition: opacity var(--transition-base);
-}
-
-body.has-overlay .background-overlay {
-    opacity: 1;
-}
-
 /* Background Type Classes */
 body.bg-gradient {
     background: var(--primary-gradient);
@@ -256,9 +245,7 @@ body.bg-image .geometric-bg {
 
 /* When using custom image or API, remove animated overlays so image is visible */
 body.bg-image::before,
-body.bg-image::after,
-body.bg-api::before,
-body.bg-api::after {
+body.bg-api::before {
     opacity: 0.0;
 }
 

--- a/newtab.css
+++ b/newtab.css
@@ -127,10 +127,22 @@ body::after {
     transition: background var(--transition-base), z-index var(--transition-base);
 }
 
-body.has-overlay::after {
+/* Dark overlay for image or gradient backgrounds */
+.background-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
     background: rgba(0, 0, 0, 0.35);
-    animation: none;
+    pointer-events: none;
     z-index: 0;
+    opacity: 0;
+    transition: opacity var(--transition-base);
+}
+
+body.has-overlay .background-overlay {
+    opacity: 1;
 }
 
 /* Floating geometric shapes */
@@ -969,7 +981,7 @@ select.form-input option {
 
 .modal-btn.primary {
     background: var(--secondary-gradient);
-    color: white;
+    color: var(--text-primary);
     border-color: transparent;
     box-shadow: var(--shadow-sm);
 }

--- a/newtab.css
+++ b/newtab.css
@@ -202,6 +202,24 @@ body::after {
     }
 }
 
+/* Overlay to ensure readability on images or gradients */
+.background-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.35);
+    pointer-events: none;
+    z-index: 0;
+    opacity: 0;
+    transition: opacity var(--transition-base);
+}
+
+body.has-overlay .background-overlay {
+    opacity: 1;
+}
+
 /* Background Type Classes */
 body.bg-gradient {
     background: var(--primary-gradient);
@@ -227,62 +245,21 @@ body.bg-image {
     background-attachment: fixed;
 }
 
-/* Ensure content is readable over background images */
-body.bg-image .dashboard-container {
-    backdrop-filter: blur(1px);
-}
-
-body.bg-image .info-card,
-body.bg-image .clock-section,
-body.bg-image .search-section,
-body.bg-image .shortcuts-section,
-body.bg-image .quote-section {
-    background: rgba(255, 255, 255, 0.15);
-    backdrop-filter: var(--backdrop-blur-strong);
-}
-
 /* API Background with semi-transparent overlay */
-body.bg-api::before {
-    content: '';
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    opacity: 0.3;
-    z-index: -4;
-    background: url('https://api.paugram.com/wallpaper/') center/cover no-repeat;
-    background-attachment: fixed;
-}
-
-/* Hide default backgrounds when using API background */
 body.bg-api .geometric-bg {
     display: none;
 }
 
-/* Enhanced readability for API background */
-body.bg-api .dashboard-container {
-    backdrop-filter: blur(1px);
-}
-
-body.bg-api .info-card,
-body.bg-api .clock-section,
-body.bg-api .search-section,
-body.bg-api .shortcuts-section,
-body.bg-api .quote-section {
-    background: rgba(255, 255, 255, 0.12);
-    backdrop-filter: var(--backdrop-blur-extreme);
-    border: 1px solid rgba(255, 255, 255, 0.15);
-}
-
-/* When using custom image or API, soften or remove animated overlays so image is visible */
-body.bg-image::before,
-body.bg-image::after,
-body.bg-api::after {
-    opacity: 0.0;
-}
 body.bg-image .geometric-bg {
     display: none;
+}
+
+/* When using custom image or API, remove animated overlays so image is visible */
+body.bg-image::before,
+body.bg-image::after,
+body.bg-api::before,
+body.bg-api::after {
+    opacity: 0.0;
 }
 
 /* Dashboard Container */
@@ -295,6 +272,8 @@ body.bg-image .geometric-bg {
     gap: var(--spacing-xl);
     max-width: var(--container-max-width);
     margin: 0 auto;
+    position: relative;
+    z-index: 1;
 }
 
 /* 主内容包装器 */
@@ -914,7 +893,7 @@ body.bg-image .geometric-bg {
 
 select.form-input option {
     background-color: #0f172a;
-    color: #f8f9fa;
+    color: var(--text-primary);
 }
 
 .icon-input-group {
@@ -1133,7 +1112,7 @@ select.form-input option {
 
 .topic-tab.active .topic-count {
     background: rgba(231, 76, 60, 0.3);
-    color: #fff;
+    color: var(--text-primary);
 }
 
 .topics-content {
@@ -1203,19 +1182,19 @@ select.form-input option {
 
 .topic-item:nth-child(1) .topic-rank {
     background: linear-gradient(135deg, #ffd700, #ffed4e);
-    color: #333;
+    color: var(--text-primary);
     font-weight: 700;
 }
 
 .topic-item:nth-child(2) .topic-rank {
     background: linear-gradient(135deg, #c0c0c0, #e8e8e8);
-    color: #333;
+    color: var(--text-primary);
     font-weight: 700;
 }
 
 .topic-item:nth-child(3) .topic-rank {
     background: linear-gradient(135deg, #cd7f32, #daa520);
-    color: #fff;
+    color: var(--text-primary);
     font-weight: 700;
 }
 

--- a/newtab.css
+++ b/newtab.css
@@ -109,24 +109,6 @@ body::before {
     z-index: -3;
 }
 
-/* Gentle mesh gradient overlay or darkening layer */
-body::after {
-    content: '';
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    pointer-events: none;
-    z-index: -2;
-    background:
-        radial-gradient(circle at 25% 25%, rgba(74, 144, 226, 0.15) 0%, transparent 60%),
-        radial-gradient(circle at 75% 75%, rgba(123, 104, 238, 0.12) 0%, transparent 60%),
-        radial-gradient(circle at 50% 50%, rgba(93, 173, 226, 0.1) 0%, transparent 60%);
-    animation: meshMove 25s ease-in-out infinite;
-    transition: background var(--transition-base), z-index var(--transition-base);
-}
-
 /* Dark overlay for image or gradient backgrounds */
 .background-overlay {
     position: fixed;
@@ -187,27 +169,8 @@ body.has-overlay .background-overlay {
     animation-delay: -10s;
 }
 
-@keyframes meshMove {
-    0%, 100% { 
-        transform: translateX(0) translateY(0) rotate(0deg);
-        filter: hue-rotate(0deg);
-    }
-    25% { 
-        transform: translateX(20px) translateY(-20px) rotate(90deg);
-        filter: hue-rotate(90deg);
-    }
-    50% { 
-        transform: translateX(-10px) translateY(30px) rotate(180deg);
-        filter: hue-rotate(180deg);
-    }
-    75% { 
-        transform: translateX(-30px) translateY(-10px) rotate(270deg);
-        filter: hue-rotate(270deg);
-    }
-}
-
 @keyframes floatShape {
-    0%, 100% { 
+    0%, 100% {
         transform: translateY(0px) translateX(0px) rotate(0deg) scale(1);
         opacity: 0.3;
     }

--- a/newtab.html
+++ b/newtab.html
@@ -13,7 +13,10 @@
         <div class="geometric-shape"></div>
         <div class="geometric-shape"></div>
     </div>
-    
+
+    <!-- Background overlay for image or gradient backgrounds -->
+    <div class="background-overlay"></div>
+
     <div id="dashboard" class="dashboard-container">
         <!-- 左侧分类导航 -->
         <aside class="category-nav">

--- a/newtab.html
+++ b/newtab.html
@@ -14,6 +14,8 @@
         <div class="geometric-shape"></div>
     </div>
 
+    <div class="background-overlay"></div>
+
     <div id="dashboard" class="dashboard-container">
         <!-- 左侧分类导航 -->
         <aside class="category-nav">

--- a/newtab.html
+++ b/newtab.html
@@ -14,9 +14,6 @@
         <div class="geometric-shape"></div>
     </div>
 
-    <!-- Background overlay for image or gradient backgrounds -->
-    <div class="background-overlay"></div>
-
     <div id="dashboard" class="dashboard-container">
         <!-- 左侧分类导航 -->
         <aside class="category-nav">

--- a/newtab.js
+++ b/newtab.js
@@ -103,6 +103,9 @@ async function applyBackgroundSettings(bgConfig) {
         default:
             body.classList.add('bg-gradient');
     }
+
+    // adjust text color and overlay based on background type
+    updateTextContrast(bgConfig);
 }
 
 /**
@@ -131,6 +134,47 @@ async function loadApiBackground() {
         document.body.classList.remove('bg-api');
         document.body.classList.add('bg-gradient');
     }
+}
+
+// Update text color and overlay based on background settings
+function updateTextContrast(bgConfig) {
+    const root = document.documentElement;
+    const body = document.body;
+
+    body.classList.remove('has-overlay');
+
+    if (bgConfig.type === 'color') {
+        const hex = bgConfig.value || '#1a1a1a';
+        const { r, g, b } = hexToRgb(hex);
+        const brightness = (0.299 * r + 0.587 * g + 0.114 * b);
+        const isLight = brightness > 186;
+        const primary = isLight ? '#000000' : '#ffffff';
+        const secondary = isLight ? 'rgba(0, 0, 0, 0.85)' : 'rgba(248, 249, 250, 0.85)';
+        const muted = isLight ? 'rgba(0, 0, 0, 0.65)' : 'rgba(248, 249, 250, 0.65)';
+
+        root.style.setProperty('--text-primary', primary);
+        root.style.setProperty('--text-secondary', secondary);
+        root.style.setProperty('--text-muted', muted);
+    } else {
+        body.classList.add('has-overlay');
+        root.style.setProperty('--text-primary', '#f8f9fa');
+        root.style.setProperty('--text-secondary', 'rgba(248, 249, 250, 0.85)');
+        root.style.setProperty('--text-muted', 'rgba(248, 249, 250, 0.65)');
+    }
+}
+
+// helper to convert hex color to rgb components
+function hexToRgb(hex) {
+    let sanitized = hex.replace('#', '');
+    if (sanitized.length === 3) {
+        sanitized = sanitized.split('').map(ch => ch + ch).join('');
+    }
+    const intVal = parseInt(sanitized, 16);
+    return {
+        r: (intVal >> 16) & 255,
+        g: (intVal >> 8) & 255,
+        b: intVal & 255
+    };
 }
 
 function applyModuleVisibility(showConfig) {


### PR DESCRIPTION
## Summary
- ensure background overlay sits above images while leaving dashboard layout intact
- unify text color declarations to use theme variables for contrast-based switching

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba708c99588331b5746680b6fa81eb