### PR TITLE
Fix quote font and quote refresh behavior

### DIFF
--- a/newtab.css
+++ b/newtab.css
@@ -90,7 +90,7 @@
     --glow-teal: 0 0 20px rgba(93, 173, 226, 0.3);
     
     /* Typography */
-    --font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+    --font-family: "Segoe UI", Arial, "Microsoft Yahei", sans-serif;
     --font-size-xs: 0.75rem;
     --font-size-sm: 0.875rem;
     --font-size-base: 1rem;
@@ -299,6 +299,19 @@ body.dashboard-hidden .dashboard-main {
 
 body.dashboard-hidden .dashboard-footer {
     width: 100%;
+}
+
+body.dashboard-hidden,
+body.dashboard-hidden::before,
+body.dashboard-hidden::after,
+body.dashboard-hidden * {
+    animation: none !important;
+    transition: none !important;
+}
+
+body.dashboard-hidden .geometric-bg,
+body.dashboard-hidden .geometric-shape {
+    display: none !important;
 }
 
 body.dashboard-hidden #quote-container {


### PR DESCRIPTION
## Summary
- force the default dashboard font stack to use Segoe UI, Arial, and Microsoft Yahei so quote text inherits the desired typography
- disable background animations when the dashboard is hidden to prevent flicker while the quote refreshes
- refresh quote placeholders every second when time tokens are present so the timestamp stays current when shortcuts are hidden

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912a8a8183c8331bfc6d49314b1bfa2)